### PR TITLE
Making the dashboard only open once in eval

### DIFF
--- a/interactive_eval.py
+++ b/interactive_eval.py
@@ -222,7 +222,7 @@ def parse_arguments(argv: Sequence[str] | None = None):
     )
     parser.add_argument(
         "--breakpoint-step",
-        "-b",
+        "-s",
         type=int,
         default=None,
         help="Episode steps to run before halting.",

--- a/traiderdaive/ray_environments/ray_hyperdrive_env.py
+++ b/traiderdaive/ray_environments/ray_hyperdrive_env.py
@@ -164,7 +164,7 @@ class RayHyperdriveEnv(MultiAgentEnv):
         self.chain = LocalChain(local_chain_config)
         self.interactive_hyperdrive = LocalHyperdrive(self.chain, initial_pool_config)
 
-        if self.eval_mode:
+        if self.eval_mode and self.worker_index == 0:
             self.chain.run_dashboard()
 
         # Instantiate the random number generator


### PR DESCRIPTION
Fixing dashboard to only run once (during actual evaluation.
Rllib calls the constructor three times, twice during initialization, and once to set up the eval env. 
In local mode, `env.worker_index` is 0 when the env is finally initialized.
Changing the CLI flag for breakpoint step to be s, for step